### PR TITLE
Fix invalidation with boto3

### DIFF
--- a/s3_deploy/deploy.py
+++ b/s3_deploy/deploy.py
@@ -11,7 +11,6 @@ from datetime import datetime
 import boto3
 
 from six import BytesIO
-from six.moves.urllib.parse import quote_plus
 
 from . import config
 from .prefixcovertree import PrefixCoverTree
@@ -234,8 +233,7 @@ def main():
                     InvalidationBatch=dict(
                         Paths=dict(
                             Quantity=len(paths),
-                            Items=['<Path>' + quote_plus(p) + '</Path>'
-                                   for p in paths]
+                            Items=paths
                         ),
                         CallerReference='s3-deploy-website'
                     )


### PR DESCRIPTION
The call to create a new invalidation on CloudFront was incorrectly ported to boto3. With boto3 the paths should not be wrapped in tags and quoted.

This fixes the invalidation bug that was pointed out in #5.