### PR TITLE
Add .ico and .svg to compressed extensions

### DIFF
--- a/s3_deploy/deploy.py
+++ b/s3_deploy/deploy.py
@@ -36,7 +36,7 @@ except ImportError:
 
 
 COMPRESSED_EXTENSIONS = frozenset([
-    '.txt', '.html', '.css', '.js', '.json', '.xml', '.rss'])
+    '.txt', '.html', '.css', '.js', '.json', '.xml', '.rss', '.ico', '.svg'])
 
 _STORAGE_STANDARD = 'STANDARD'
 _STORAGE_REDUCED_REDUDANCY = 'REDUCED_REDUNDANCY'


### PR DESCRIPTION
* The `.ico` extension is used for favicon which usually contain uncompressed bitmaps.
* The `.svg` extension is used for the XML based SVG (Scalable Vector Graphics) format.