### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: python
-install: pip install tox python-coveralls
+install: pip install tox tox-venv python-coveralls
 script: tox -v
 after_success: coveralls
+
+env:
+  global:
+    # Workaround for moto issue: https://github.com/spulec/moto/issues/1771
+    - BOTO_CONFIG=/dev/null
+    - TOX_TESTENV_PASSENV="BOTO_CONFIG"
 
 matrix:
   include:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
 
@@ -35,11 +36,15 @@ setup(
         ]
     },
     install_requires=[
-        'boto3', 'PyYAML', 'six'
+        # moto is unable to test >=1.8 currently
+        # https://github.com/spulec/moto/issues/1793
+        'boto3>=1.7,<1.8',
+        'PyYAML~=3.11',
+        'six~=1.10',
     ],
     test_suite='s3_deploy.tests',
     tests_require=[
-        'mock',
-        'moto',
+        'mock~=2.0',
+        'moto~=1.1',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py34,
     py35,
     py36,
+    py37,
     coverage,
     flake
 


### PR DESCRIPTION
- Fixes Travis CI build and tests
- Pins dependencies to major versions
- We also have to restrict the boto3 version to <1.8 for now since moto doesn't work with later versions yet: https://github.com/spulec/moto/issues/1793