### PR TITLE
Fix failing flake8 checks

### DIFF
--- a/s3_deploy/tests/test_filematch.py
+++ b/s3_deploy/tests/test_filematch.py
@@ -83,24 +83,24 @@ class FileMatchTest(unittest.TestCase):
 
     def test_match_regex_dollar_suffix_ok(self):
         self.assertTrue(filematch.match_key(
-            'image-\d+\.png$', 'image-999.png', regexp=True))
+            r'image-\d+\.png$', 'image-999.png', regexp=True))
 
     def test_match_regex_dollar_suffix_fail(self):
         self.assertFalse(filematch.match_key(
-            'image-\d+\.png$', 'image-name.png', regexp=True))
+            r'image-\d+\.png$', 'image-name.png', regexp=True))
 
     def test_match_regex_caret_prefix_ok(self):
         self.assertTrue(filematch.match_key(
-            '^dir\/index\.html', 'dir/index.html', regexp=True))
+            r'^dir\/index\.html', 'dir/index.html', regexp=True))
 
     def test_match_regex_caret_prefix_fail(self):
         self.assertFalse(filematch.match_key(
-            '^dir\/index\.html', 'altdir/index.html', regexp=True))
+            r'^dir\/index\.html', 'altdir/index.html', regexp=True))
 
     def test_match_regex_caret_and_dollar_ok(self):
         self.assertTrue(filematch.match_key(
-            '^dir\/index\.html$', 'dir/index.html', regexp=True))
+            r'^dir\/index\.html$', 'dir/index.html', regexp=True))
 
     def test_match_regex_caret_and_dollar_fail(self):
         self.assertFalse(filematch.match_key(
-            '^dir\/index\.html$', 'dir/index.htm', regexp=True))
+            r'^dir\/index\.html$', 'dir/index.htm', regexp=True))

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     flake
 
 [flake8]
-ignore = E226,D101,D102,D103,D104,D203
+ignore = E226,D101,D102,D103,D104,D203,W503,W504
 
 [testenv]
 deps = coverage


### PR DESCRIPTION
Disable some new flake8 checks that should be disabled by default. The ignore list in `tox.ini` overrides the default so newly added checks must be added manually. Fix some recent tests that violate another check.